### PR TITLE
Handle missing MFA method in login process

### DIFF
--- a/firstrade/account.py
+++ b/firstrade/account.py
@@ -8,6 +8,7 @@ import requests
 from firstrade import urls
 from firstrade.exceptions import (
     AccountResponseError,
+    LoginError,
     LoginRequestError,
     LoginResponseError,
 )
@@ -262,7 +263,7 @@ class FTSession:
             }
             response = self.session.post(urls.verify_pin(), data=data)
         else:
-            raise LoginResponseError(
+            raise LoginError(
                 "MFA required but no valid MFA method "
                 "was provided (pin, email/phone, or mfa_secret)."
             )


### PR DESCRIPTION
Fix #72

Raise error if no valid MFA method is provided during login:
```bash
$ ./test.py 
Traceback (most recent call last):
  File "/home/da/./test.py", line 8, in <module>
    need_code = ft_ss.login()
                ^^^^^^^^^^^^^
  File "/home/da/.local/lib/python3.12/site-packages/firstrade/account.py", line 134, in login
    need_code = self._handle_mfa()
                ^^^^^^^^^^^^^^^^^^
  File "/home/da/.local/lib/python3.12/site-packages/firstrade/account.py", line 266, in _handle_mfa
    raise LoginError(
firstrade.exceptions.LoginError: MFA required but no valid MFA method was provided (pin, email/phone, or mfa_secret).
```